### PR TITLE
added small patch to run http only

### DIFF
--- a/lib/src/main/java/cis5550/webserver/Server.java
+++ b/lib/src/main/java/cis5550/webserver/Server.java
@@ -238,6 +238,11 @@ public class Server implements AutoCloseable {
     }
 
     private void listen(ServerSocket ssock, int maxRetry) {
+
+        // https socket could be null if it throws an exception
+        if (ssock == null)
+            return;
+
         logger.info("Listening on " + ssock.getInetAddress() + ":" + ssock.getLocalPort());
         int ex = 0;
         while (maxRetry < 0 || ex <= maxRetry) {

--- a/lib/src/main/java/cis5550/webserver/Server.java
+++ b/lib/src/main/java/cis5550/webserver/Server.java
@@ -219,7 +219,8 @@ public class Server implements AutoCloseable {
             this.secureSsock = factory.createServerSocket(this.securePort);
             logger.info("Server Started on port " + this.securePort + "(HTTPS)");
         } catch (Exception e) {
-            logger.error("Could not start HTTPS server", e);
+            // just so it does not clog up console
+            logger.warn("Could not start HTTPS server");
         }
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {


### PR DESCRIPTION
If secure socket throws exception, secure socket is null which causes an error in the listen thread